### PR TITLE
Restructure admin dashboard with new sidebar navigation

### DIFF
--- a/client/App.tsx
+++ b/client/App.tsx
@@ -22,6 +22,8 @@ import Sollatek from "./pages/services/Sollatek";
 import Layout from "./components/site/Layout";
 import AdminLogin from "./pages/admin/AdminLogin";
 import AdminDashboard from "./pages/admin/AdminDashboard";
+import AdminLatestLead from "./pages/admin/AdminLatestLead";
+import AdminTeam from "./pages/admin/AdminTeam";
 import AdminSignup from "./pages/admin/AdminSignup";
 import AdminAuthLayout from "./components/admin/AdminAuthLayout";
 import AdminAppLayout from "./components/admin/AdminAppLayout";
@@ -60,6 +62,8 @@ const App = () => (
           </Route>
           <Route path="/admin-rank/dashboard" element={<AdminAppLayout />}>
             <Route index element={<AdminDashboard />} />
+            <Route path="latest-lead" element={<AdminLatestLead />} />
+            <Route path="team" element={<AdminTeam />} />
           </Route>
         </Routes>
       </BrowserRouter>

--- a/client/App.tsx
+++ b/client/App.tsx
@@ -22,7 +22,9 @@ import Sollatek from "./pages/services/Sollatek";
 import Layout from "./components/site/Layout";
 import AdminLogin from "./pages/admin/AdminLogin";
 import AdminDashboard from "./pages/admin/AdminDashboard";
-import AdminLatestLead from "./pages/admin/AdminLatestLead";
+import AdminSubmissions from "./pages/admin/AdminSubmissions";
+import AdminNewToday from "./pages/admin/AdminNewToday";
+import AdminActiveAdmins from "./pages/admin/AdminActiveAdmins";
 import AdminTeam from "./pages/admin/AdminTeam";
 import AdminSignup from "./pages/admin/AdminSignup";
 import AdminAuthLayout from "./components/admin/AdminAuthLayout";
@@ -62,7 +64,9 @@ const App = () => (
           </Route>
           <Route path="/admin-rank/dashboard" element={<AdminAppLayout />}>
             <Route index element={<AdminDashboard />} />
-            <Route path="latest-lead" element={<AdminLatestLead />} />
+            <Route path="recent" element={<AdminSubmissions />} />
+            <Route path="new-today" element={<AdminNewToday />} />
+            <Route path="active-admins" element={<AdminActiveAdmins />} />
             <Route path="team" element={<AdminTeam />} />
           </Route>
         </Routes>

--- a/client/components/admin/AdminAppLayout.tsx
+++ b/client/components/admin/AdminAppLayout.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from "react";
-import { useEffect, useState } from "react";
 import { Outlet, NavLink, useLocation, useNavigate } from "react-router-dom";
 import type { LucideIcon } from "lucide-react";
 import { LayoutDashboard, LogOut, Menu, ShieldCheck, X } from "lucide-react";

--- a/client/components/admin/AdminAppLayout.tsx
+++ b/client/components/admin/AdminAppLayout.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { Outlet, NavLink, useLocation, useNavigate } from "react-router-dom";
 import type { LucideIcon } from "lucide-react";
-import { LayoutDashboard, LogOut, Menu, ShieldCheck, X } from "lucide-react";
+import { LayoutDashboard, LogOut, Menu, ShieldCheck, X, Mail, Users } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import SnakeCursor from "@/components/site/cursors/SnakeCursor";
@@ -13,6 +13,16 @@ const NAV_LINKS: Array<{ to: string; label: string; icon: LucideIcon }> = [
     to: "/admin-rank/dashboard",
     label: "Overview",
     icon: LayoutDashboard,
+  },
+  {
+    to: "/admin-rank/dashboard/latest-lead",
+    label: "Latest lead",
+    icon: Mail,
+  },
+  {
+    to: "/admin-rank/dashboard/team",
+    label: "Admin team",
+    icon: Users,
   },
 ];
 

--- a/client/components/admin/AdminAppLayout.tsx
+++ b/client/components/admin/AdminAppLayout.tsx
@@ -1,7 +1,16 @@
 import { useEffect, useState } from "react";
 import { Outlet, NavLink, useLocation, useNavigate } from "react-router-dom";
 import type { LucideIcon } from "lucide-react";
-import { LayoutDashboard, LogOut, Menu, ShieldCheck, X, Users, Clock3, ListChecks } from "lucide-react";
+import {
+  LayoutDashboard,
+  LogOut,
+  Menu,
+  ShieldCheck,
+  X,
+  Users,
+  Clock3,
+  ListChecks,
+} from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import SnakeCursor from "@/components/site/cursors/SnakeCursor";

--- a/client/components/admin/AdminAppLayout.tsx
+++ b/client/components/admin/AdminAppLayout.tsx
@@ -4,6 +4,7 @@ import type { LucideIcon } from "lucide-react";
 import { LayoutDashboard, LogOut, Menu, ShieldCheck, X } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import SnakeCursor from "@/components/site/cursors/SnakeCursor";
 import { cn } from "@/lib/utils";
 import { isAuthed, logout } from "@/lib/submissions";
 
@@ -37,7 +38,8 @@ export default function AdminAppLayout() {
 
   return (
     <div className="flex min-h-screen bg-slate-100 text-slate-900">
-      <aside className="hidden w-72 flex-col border-r border-slate-200 bg-slate-950 text-white lg:flex">
+      <SnakeCursor />
+      <aside className="hidden w-80 flex-col border-r border-slate-200 bg-slate-950 text-white lg:flex">
         <AdminSidebarContent />
       </aside>
 
@@ -51,7 +53,7 @@ export default function AdminAppLayout() {
 
       <aside
         className={cn(
-          "fixed inset-y-0 left-0 z-50 w-72 translate-x-[-100%] border-r border-slate-200 bg-slate-950 text-white transition-transform lg:hidden",
+          "fixed inset-y-0 left-0 z-50 w-80 translate-x-[-100%] border-r border-slate-200 bg-slate-950 text-white transition-transform lg:hidden",
           sidebarOpen && "translate-x-0",
         )}
       >
@@ -108,7 +110,7 @@ export default function AdminAppLayout() {
             Sign out
           </Button>
         </header>
-        <main className="flex-1 overflow-y-auto bg-slate-50 px-4 py-8 lg:px-8">
+        <main className="flex-1 overflow-y-auto bg-slate-50 px-6 py-10 md:px-8 lg:px-12">
           <Outlet />
         </main>
       </div>
@@ -135,7 +137,7 @@ function AdminSidebarContent() {
           <SidebarLink key={item.to} {...item} />
         ))}
       </nav>
-      <div className="px-6 pb-10 text-xs text-white/50">
+      <div className="px-8 pb-10 text-xs text-white/50">
         Organized operations for the JBRANKY team.
       </div>
     </div>
@@ -155,7 +157,7 @@ function SidebarLink({ to, label, icon: Icon }: (typeof NAV_LINKS)[number]) {
         )
       }
     >
-      <Icon className="h-4 w-4" />
+      <Icon className="h-4 w-4" aria-hidden="true" />
       <span>{label}</span>
     </NavLink>
   );

--- a/client/components/admin/AdminAppLayout.tsx
+++ b/client/components/admin/AdminAppLayout.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { Outlet, NavLink, useLocation, useNavigate } from "react-router-dom";
 import type { LucideIcon } from "lucide-react";
-import { LayoutDashboard, LogOut, Menu, ShieldCheck, X, Mail, Users } from "lucide-react";
+import { LayoutDashboard, LogOut, Menu, ShieldCheck, X, Users, Clock3, ListChecks } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import SnakeCursor from "@/components/site/cursors/SnakeCursor";
@@ -15,9 +15,19 @@ const NAV_LINKS: Array<{ to: string; label: string; icon: LucideIcon }> = [
     icon: LayoutDashboard,
   },
   {
-    to: "/admin-rank/dashboard/latest-lead",
-    label: "Latest lead",
-    icon: Mail,
+    to: "/admin-rank/dashboard/recent",
+    label: "Recent submissions",
+    icon: ListChecks,
+  },
+  {
+    to: "/admin-rank/dashboard/new-today",
+    label: "New today",
+    icon: Clock3,
+  },
+  {
+    to: "/admin-rank/dashboard/active-admins",
+    label: "Active admins",
+    icon: Users,
   },
   {
     to: "/admin-rank/dashboard/team",

--- a/client/components/admin/AdminAuthLayout.tsx
+++ b/client/components/admin/AdminAuthLayout.tsx
@@ -1,5 +1,6 @@
 import { Outlet, useNavigate } from "react-router-dom";
 import { useEffect } from "react";
+import SnakeCursor from "@/components/site/cursors/SnakeCursor";
 
 import { isAuthed } from "@/lib/submissions";
 
@@ -14,6 +15,7 @@ export default function AdminAuthLayout() {
 
   return (
     <div className="relative min-h-screen overflow-hidden bg-slate-950 text-white">
+      <SnakeCursor />
       <div className="pointer-events-none absolute inset-0">
         <div className="absolute -top-32 right-[-20%] h-[520px] w-[520px] rounded-full bg-primary/25 blur-3xl" />
         <div className="absolute bottom-[-24%] left-[-16%] h-[460px] w-[460px] rounded-full bg-indigo-500/20 blur-3xl" />

--- a/client/components/admin/AdminAuthLayout.tsx
+++ b/client/components/admin/AdminAuthLayout.tsx
@@ -1,6 +1,5 @@
 import { Outlet, useNavigate } from "react-router-dom";
 import { useEffect } from "react";
-import { Outlet, useNavigate } from "react-router-dom";
 
 import { isAuthed } from "@/lib/submissions";
 

--- a/client/lib/submissions.ts
+++ b/client/lib/submissions.ts
@@ -226,6 +226,13 @@ export async function updateSubmissionStatus(
   return mapSubmission(data);
 }
 
+export async function deleteSubmission(id: number) {
+  await apiFetch<void>(`/api/requests/${id}/`, {
+    method: "DELETE",
+    expectJson: false,
+  });
+}
+
 export function clearAuth() {
   setToken(null);
 }

--- a/client/pages/admin/AdminActiveAdmins.tsx
+++ b/client/pages/admin/AdminActiveAdmins.tsx
@@ -3,16 +3,27 @@ import { useQuery } from "@tanstack/react-query";
 import { getAdminUsers } from "@/lib/submissions";
 
 export default function AdminActiveAdmins() {
-  const usersQuery = useQuery({ queryKey: ["admin", "users"], queryFn: getAdminUsers });
+  const usersQuery = useQuery({
+    queryKey: ["admin", "users"],
+    queryFn: getAdminUsers,
+  });
   const users = (usersQuery.data ?? []).filter((u) => u.is_active ?? true);
 
   return (
     <section className="mx-auto w-full max-w-3xl">
       <div className="mb-6">
-        <h1 className="text-2xl font-semibold text-slate-900 md:text-3xl">Active admins</h1>
-        <p className="text-sm text-muted-foreground md:text-base">Only currently active accounts are shown.</p>
+        <h1 className="text-2xl font-semibold text-slate-900 md:text-3xl">
+          Active admins
+        </h1>
+        <p className="text-sm text-muted-foreground md:text-base">
+          Only currently active accounts are shown.
+        </p>
       </div>
-      <UsersCard users={users} loading={usersQuery.isLoading} fetching={usersQuery.isFetching} />
+      <UsersCard
+        users={users}
+        loading={usersQuery.isLoading}
+        fetching={usersQuery.isFetching}
+      />
     </section>
   );
 }

--- a/client/pages/admin/AdminActiveAdmins.tsx
+++ b/client/pages/admin/AdminActiveAdmins.tsx
@@ -1,0 +1,18 @@
+import UsersCard from "./components/UsersCard";
+import { useQuery } from "@tanstack/react-query";
+import { getAdminUsers } from "@/lib/submissions";
+
+export default function AdminActiveAdmins() {
+  const usersQuery = useQuery({ queryKey: ["admin", "users"], queryFn: getAdminUsers });
+  const users = (usersQuery.data ?? []).filter((u) => u.is_active ?? true);
+
+  return (
+    <section className="mx-auto w-full max-w-3xl">
+      <div className="mb-6">
+        <h1 className="text-2xl font-semibold text-slate-900 md:text-3xl">Active admins</h1>
+        <p className="text-sm text-muted-foreground md:text-base">Only currently active accounts are shown.</p>
+      </div>
+      <UsersCard users={users} loading={usersQuery.isLoading} fetching={usersQuery.isFetching} />
+    </section>
+  );
+}

--- a/client/pages/admin/AdminDashboard.tsx
+++ b/client/pages/admin/AdminDashboard.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import {
   Activity,
   CheckCircle2,
@@ -300,29 +300,6 @@ export default function AdminDashboard() {
         loading={submissionsQuery.isLoading && submissions.length === 0}
       />
 
-      <div className="grid gap-6 xl:grid-cols-[2fr_1fr]">
-        <SubmissionsPanel
-          items={filteredSubmissions}
-          totalItems={sortedSubmissions.length}
-          onRefresh={() => submissionsQuery.refetch()}
-          loading={submissionsQuery.isLoading}
-          fetching={submissionsQuery.isFetching}
-          typeFilter={typeFilter}
-          onTypeFilterChange={setTypeFilter}
-          statusFilter={statusFilter}
-          onStatusFilterChange={setStatusFilter}
-          searchTerm={searchTerm}
-          onSearchChange={setSearchTerm}
-          onToggleReviewed={handleToggleReviewed}
-          onDelete={handleDelete}
-          updatingId={updatingId}
-        />
-
-        <aside className="space-y-6">
-          <LatestLeadCard submission={latestSubmission} loading={submissionsQuery.isLoading} />
-          <UsersCard users={adminUsers} loading={adminUsersQuery.isLoading} fetching={adminUsersQuery.isFetching} />
-        </aside>
-      </div>
     </section>
   );
 }
@@ -349,12 +326,14 @@ function OverviewMetrics({
           : "No new inquiries this week",
       value: metrics.total.toLocaleString(),
       icon: Activity,
+      to: "/admin-rank/dashboard/recent",
     },
     {
       label: "Review rate",
       helper: `${metrics.reviewed} marked as reviewed`,
       value: `${reviewRate}%`,
       icon: CheckCircle2,
+      to: "/admin-rank/dashboard/recent?status=reviewed",
     },
     {
       label: "New today",
@@ -364,19 +343,23 @@ function OverviewMetrics({
           : "All submissions are reviewed",
       value: metrics.today.toLocaleString(),
       icon: Clock3,
+      to: "/admin-rank/dashboard/new-today",
     },
     {
       label: "Active admins",
       helper: `${totalAdmins} team member${totalAdmins === 1 ? "" : "s"}`,
       value: activeAdmins.toString(),
       icon: Users,
+      to: "/admin-rank/dashboard/active-admins",
     },
   ];
 
   return (
     <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-4">
       {cards.map((card) => (
-        <MetricCard key={card.label} {...card} loading={loading} />
+        <Link key={card.label} to={(card as any).to} className="block">
+          <MetricCard {...card} loading={loading} />
+        </Link>
       ))}
     </div>
   );

--- a/client/pages/admin/AdminDashboard.tsx
+++ b/client/pages/admin/AdminDashboard.tsx
@@ -431,6 +431,7 @@ function SubmissionsPanel({
   searchTerm,
   onSearchChange,
   onToggleReviewed,
+  onDelete,
   updatingId,
 }: {
   items: Submission[];

--- a/client/pages/admin/AdminDashboard.tsx
+++ b/client/pages/admin/AdminDashboard.tsx
@@ -611,16 +611,39 @@ function SubmissionRow({
         <StatusBadge submission={submission} />
       </td>
       <td className="px-4 py-4 text-right">
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          onClick={() => onToggleReviewed(submission)}
-          disabled={updating}
-        >
-          {updating && <Loader2 className="h-4 w-4 animate-spin" />}
-          Mark as {submission.reviewed ? "new" : "reviewed"}
-        </Button>
+        <div className="flex items-center justify-end gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => onToggleReviewed(submission)}
+            disabled={updating}
+          >
+            {updating && <Loader2 className="h-4 w-4 animate-spin" />}
+            Mark as {submission.reviewed ? "new" : "reviewed"}
+          </Button>
+          <AlertDialog>
+            <AlertDialogTrigger asChild>
+              <Button variant="destructive" size="sm" disabled={updating}>
+                <Trash2 className="h-4 w-4" /> Delete
+              </Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Delete this submission?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  This action cannot be undone. This will permanently remove the selected submission.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                <AlertDialogAction onClick={() => onDelete(submission)}>
+                  Delete
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        </div>
       </td>
     </tr>
   );

--- a/client/pages/admin/AdminDashboard.tsx
+++ b/client/pages/admin/AdminDashboard.tsx
@@ -445,6 +445,7 @@ function SubmissionsPanel({
   searchTerm: string;
   onSearchChange: (value: string) => void;
   onToggleReviewed: (submission: Submission) => void;
+  onDelete: (submission: Submission) => void;
   updatingId: number | null;
 }) {
   const showEmptyState = !loading && items.length === 0;

--- a/client/pages/admin/AdminDashboard.tsx
+++ b/client/pages/admin/AdminDashboard.tsx
@@ -556,10 +556,12 @@ function SubmissionsPanel({
 function SubmissionRow({
   submission,
   onToggleReviewed,
+  onDelete,
   updating,
 }: {
   submission: Submission;
   onToggleReviewed: (submission: Submission) => void;
+  onDelete: (submission: Submission) => void;
   updating: boolean;
 }) {
   const createdAt = new Date(submission.createdAt);

--- a/client/pages/admin/AdminDashboard.tsx
+++ b/client/pages/admin/AdminDashboard.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useMemo, useState } from "react";
-import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import {
   Activity,

--- a/client/pages/admin/AdminDashboard.tsx
+++ b/client/pages/admin/AdminDashboard.tsx
@@ -254,7 +254,8 @@ export default function AdminDashboard() {
       await deleteSubmission(submission.id);
       queryClient.setQueryData<Submission[] | undefined>(
         ["admin", "submissions"],
-        (current) => (current ? current.filter((s) => s.id !== submission.id) : []),
+        (current) =>
+          current ? current.filter((s) => s.id !== submission.id) : [],
       );
       toast.success("Submission deleted");
     } catch (error) {
@@ -299,7 +300,6 @@ export default function AdminDashboard() {
         totalAdmins={adminUsers.length}
         loading={submissionsQuery.isLoading && submissions.length === 0}
       />
-
     </section>
   );
 }
@@ -611,7 +611,8 @@ function SubmissionRow({
               <AlertDialogHeader>
                 <AlertDialogTitle>Delete this submission?</AlertDialogTitle>
                 <AlertDialogDescription>
-                  This action cannot be undone. This will permanently remove the selected submission.
+                  This action cannot be undone. This will permanently remove the
+                  selected submission.
                 </AlertDialogDescription>
               </AlertDialogHeader>
               <AlertDialogFooter>
@@ -681,7 +682,6 @@ function FilterPill({
     </button>
   );
 }
-
 
 function labelForType(submission: Submission) {
   switch (submission.normalizedType) {

--- a/client/pages/admin/AdminDashboard.tsx
+++ b/client/pages/admin/AdminDashboard.tsx
@@ -7,6 +7,7 @@ import {
   Loader2,
   Mail,
   Search,
+  Trash2,
   Users,
 } from "lucide-react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
@@ -33,7 +34,19 @@ import {
   getSubmissions,
   isAuthed,
   updateSubmissionStatus,
+  deleteSubmission,
 } from "@/lib/submissions";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 
 type InquiryFilter = "all" | "service" | "consultation" | "general";
 type StatusFilter = "all" | "new" | "reviewed";
@@ -233,7 +246,7 @@ export default function AdminDashboard() {
   };
 
   return (
-    <section className="mx-auto flex w-full max-w-7xl flex-col gap-8">
+    <section className="mx-auto flex w-full max-w-6xl flex-col gap-10">
       <header className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
         <div>
           <h1 className="text-2xl font-semibold text-slate-900 md:text-3xl">

--- a/client/pages/admin/AdminDashboard.tsx
+++ b/client/pages/admin/AdminDashboard.tsx
@@ -245,6 +245,25 @@ export default function AdminDashboard() {
     }
   };
 
+  const handleDelete = async (submission: Submission) => {
+    if (updatingId) return;
+    setUpdatingId(submission.id);
+    try {
+      await deleteSubmission(submission.id);
+      queryClient.setQueryData<Submission[] | undefined>(
+        ["admin", "submissions"],
+        (current) => (current ? current.filter((s) => s.id !== submission.id) : []),
+      );
+      toast.success("Submission deleted");
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Unable to delete submission.";
+      toast.error(message);
+    } finally {
+      setUpdatingId(null);
+    }
+  };
+
   return (
     <section className="mx-auto flex w-full max-w-6xl flex-col gap-10">
       <header className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">

--- a/client/pages/admin/AdminDashboard.tsx
+++ b/client/pages/admin/AdminDashboard.tsx
@@ -312,6 +312,7 @@ export default function AdminDashboard() {
           searchTerm={searchTerm}
           onSearchChange={setSearchTerm}
           onToggleReviewed={handleToggleReviewed}
+          onDelete={handleDelete}
           updatingId={updatingId}
         />
 

--- a/client/pages/admin/AdminDashboard.tsx
+++ b/client/pages/admin/AdminDashboard.tsx
@@ -379,7 +379,7 @@ function OverviewMetrics({
   ];
 
   return (
-    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+    <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-4">
       {cards.map((card) => (
         <MetricCard key={card.label} {...card} loading={loading} />
       ))}

--- a/client/pages/admin/AdminDashboard.tsx
+++ b/client/pages/admin/AdminDashboard.tsx
@@ -539,6 +539,7 @@ function SubmissionsPanel({
                       key={submission.id}
                       submission={submission}
                       onToggleReviewed={onToggleReviewed}
+                      onDelete={onDelete}
                       updating={updatingId === submission.id}
                     />
                   ))

--- a/client/pages/admin/AdminDashboard.tsx
+++ b/client/pages/admin/AdminDashboard.tsx
@@ -47,6 +47,8 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
+import LatestLeadCard from "./components/LatestLeadCard";
+import UsersCard from "./components/UsersCard";
 
 type InquiryFilter = "all" | "service" | "consultation" | "general";
 type StatusFilter = "all" | "new" | "reviewed";
@@ -317,15 +319,8 @@ export default function AdminDashboard() {
         />
 
         <aside className="space-y-6">
-          <LatestLeadCard
-            submission={latestSubmission}
-            loading={submissionsQuery.isLoading}
-          />
-          <UsersCard
-            users={adminUsers}
-            loading={adminUsersQuery.isLoading}
-            fetching={adminUsersQuery.isFetching}
-          />
+          <LatestLeadCard submission={latestSubmission} loading={submissionsQuery.isLoading} />
+          <UsersCard users={adminUsers} loading={adminUsersQuery.isLoading} fetching={adminUsersQuery.isFetching} />
         </aside>
       </div>
     </section>
@@ -704,141 +699,6 @@ function FilterPill({
   );
 }
 
-function LatestLeadCard({
-  submission,
-  loading,
-}: {
-  submission: Submission | null;
-  loading: boolean;
-}) {
-  return (
-    <Card className="border-none bg-white shadow-sm">
-      <CardHeader>
-        <CardTitle>Latest lead</CardTitle>
-        <CardDescription>
-          {submission
-            ? "Most recent inbound inquiry."
-            : "New leads appear here."}
-        </CardDescription>
-      </CardHeader>
-      <CardContent>
-        {loading ? (
-          <div className="flex items-center justify-center py-12 text-muted-foreground">
-            <Loader2 className="h-5 w-5 animate-spin" />
-          </div>
-        ) : submission ? (
-          <div className="space-y-4">
-            <div>
-              <p className="text-lg font-semibold text-slate-900">
-                {submission.name}
-              </p>
-              <p className="text-sm text-muted-foreground">
-                {submission.email}
-              </p>
-            </div>
-            <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
-              <Badge variant="secondary">{labelForType(submission)}</Badge>
-              {submission.service && (
-                <Badge variant="outline">
-                  {formatService(submission.service)}
-                </Badge>
-              )}
-            </div>
-            <Separator />
-            <p className="text-sm leading-relaxed text-muted-foreground">
-              {submission.message}
-            </p>
-            <p className="text-xs text-muted-foreground">
-              {formatDistanceToNow(new Date(submission.createdAt), {
-                addSuffix: true,
-              })}
-            </p>
-          </div>
-        ) : (
-          <p className="py-8 text-sm text-muted-foreground">
-            You are all caught up. Invite prospects to reach out via the contact
-            page to see their messages here.
-          </p>
-        )}
-      </CardContent>
-    </Card>
-  );
-}
-
-function UsersCard({
-  users,
-  loading,
-  fetching,
-}: {
-  users: AdminUser[];
-  loading: boolean;
-  fetching: boolean;
-}) {
-  return (
-    <Card className="border-none bg-white shadow-sm">
-      <CardHeader className="flex flex-row items-start justify-between">
-        <div>
-          <CardTitle>Admin team</CardTitle>
-          <CardDescription>
-            Accounts with access to this console.
-          </CardDescription>
-        </div>
-        {fetching && <Loader2 className="h-4 w-4 animate-spin text-primary" />}
-      </CardHeader>
-      <CardContent>
-        {loading ? (
-          <div className="flex items-center justify-center py-12 text-muted-foreground">
-            <Loader2 className="h-5 w-5 animate-spin" />
-          </div>
-        ) : users.length === 0 ? (
-          <p className="py-8 text-sm text-muted-foreground">
-            No admins found. Share the signup link to onboard your team.
-          </p>
-        ) : (
-          <ScrollArea className="max-h-[420px] pr-2">
-            <div className="space-y-4">
-              {users.map((user) => (
-                <UserRow key={user.id} user={user} />
-              ))}
-            </div>
-          </ScrollArea>
-        )}
-      </CardContent>
-    </Card>
-  );
-}
-
-function UserRow({ user }: { user: AdminUser }) {
-  const lastLoginLabel = user.last_login
-    ? formatDistanceToNow(new Date(user.last_login), { addSuffix: true })
-    : "No activity recorded";
-
-  return (
-    <div className="rounded-lg border border-border bg-muted/30 p-4">
-      <div className="flex items-start justify-between gap-4">
-        <div>
-          <p className="text-sm font-semibold text-slate-900">
-            {user.username}
-          </p>
-          <p className="text-xs text-muted-foreground">{user.email}</p>
-        </div>
-        <Badge
-          variant={user.is_active === false ? "outline" : "secondary"}
-          className={cn(
-            user.is_active === false
-              ? "border-amber-300 text-amber-600"
-              : "bg-emerald-100 text-emerald-700",
-          )}
-        >
-          {user.is_active === false ? "Inactive" : "Active"}
-        </Badge>
-      </div>
-      <p className="mt-3 text-xs text-muted-foreground">
-        Last login: {lastLoginLabel}
-      </p>
-    </div>
-  );
-}
 
 function labelForType(submission: Submission) {
   switch (submission.normalizedType) {

--- a/client/pages/admin/AdminLatestLead.tsx
+++ b/client/pages/admin/AdminLatestLead.tsx
@@ -1,0 +1,19 @@
+import { useMemo } from "react";
+import LatestLeadCard from "./components/LatestLeadCard";
+import { useQuery } from "@tanstack/react-query";
+import { getSubmissions } from "@/lib/submissions";
+
+export default function AdminLatestLead() {
+  const submissionsQuery = useQuery({ queryKey: ["admin", "submissions"], queryFn: getSubmissions });
+  const latest = useMemo(() => (submissionsQuery.data ?? [])[0] ?? null, [submissionsQuery.data]);
+
+  return (
+    <section className="mx-auto w-full max-w-3xl">
+      <div className="mb-6">
+        <h1 className="text-2xl font-semibold text-slate-900 md:text-3xl">Latest lead</h1>
+        <p className="text-sm text-muted-foreground md:text-base">Most recent inbound inquiry details.</p>
+      </div>
+      <LatestLeadCard submission={latest} loading={submissionsQuery.isLoading} />
+    </section>
+  );
+}

--- a/client/pages/admin/AdminLatestLead.tsx
+++ b/client/pages/admin/AdminLatestLead.tsx
@@ -4,16 +4,29 @@ import { useQuery } from "@tanstack/react-query";
 import { getSubmissions } from "@/lib/submissions";
 
 export default function AdminLatestLead() {
-  const submissionsQuery = useQuery({ queryKey: ["admin", "submissions"], queryFn: getSubmissions });
-  const latest = useMemo(() => (submissionsQuery.data ?? [])[0] ?? null, [submissionsQuery.data]);
+  const submissionsQuery = useQuery({
+    queryKey: ["admin", "submissions"],
+    queryFn: getSubmissions,
+  });
+  const latest = useMemo(
+    () => (submissionsQuery.data ?? [])[0] ?? null,
+    [submissionsQuery.data],
+  );
 
   return (
     <section className="mx-auto w-full max-w-3xl">
       <div className="mb-6">
-        <h1 className="text-2xl font-semibold text-slate-900 md:text-3xl">Latest lead</h1>
-        <p className="text-sm text-muted-foreground md:text-base">Most recent inbound inquiry details.</p>
+        <h1 className="text-2xl font-semibold text-slate-900 md:text-3xl">
+          Latest lead
+        </h1>
+        <p className="text-sm text-muted-foreground md:text-base">
+          Most recent inbound inquiry details.
+        </p>
       </div>
-      <LatestLeadCard submission={latest} loading={submissionsQuery.isLoading} />
+      <LatestLeadCard
+        submission={latest}
+        loading={submissionsQuery.isLoading}
+      />
     </section>
   );
 }

--- a/client/pages/admin/AdminNewToday.tsx
+++ b/client/pages/admin/AdminNewToday.tsx
@@ -1,0 +1,10 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+
+export default function AdminNewToday() {
+  const navigate = useNavigate();
+  useEffect(() => {
+    navigate("/admin-rank/dashboard/recent?date=today", { replace: true });
+  }, [navigate]);
+  return null;
+}

--- a/client/pages/admin/AdminSubmissions.tsx
+++ b/client/pages/admin/AdminSubmissions.tsx
@@ -1,0 +1,256 @@
+import { useEffect, useMemo, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { Link, useSearchParams } from "react-router-dom";
+import { format, formatDistanceToNow, isToday } from "date-fns";
+import { toast } from "sonner";
+import {
+  Submission,
+  getSubmissions,
+  updateSubmissionStatus,
+  deleteSubmission,
+} from "@/lib/submissions";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Separator } from "@/components/ui/separator";
+import { Loader2, Mail, Search, Trash2 } from "lucide-react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+
+function labelForType(submission: Submission) {
+  switch (submission.normalizedType) {
+    case "service":
+      return "Service request";
+    case "consultation":
+      return "Consultation";
+    case "general":
+      return "General inquiry";
+    default:
+      return submission.type || "Other";
+  }
+}
+
+function formatService(value: string) {
+  switch (value) {
+    case "hydropower":
+      return "Hydropower";
+    case "mv":
+      return "Large Power & MV";
+    case "sollatek":
+      return "Sollatek Protection";
+    default:
+      return value;
+  }
+}
+
+function StatusBadge({ submission }: { submission: Submission }) {
+  if (submission.reviewed) {
+    return (
+      <Badge className="bg-emerald-100 text-emerald-700 hover:bg-emerald-100">Reviewed</Badge>
+    );
+  }
+  return (
+    <Badge variant="outline" className="border-amber-300 text-amber-600">Awaiting review</Badge>
+  );
+}
+
+export default function AdminSubmissions() {
+  const [params] = useSearchParams();
+  const statusParam = params.get("status");
+  const dateParam = params.get("date");
+
+  const queryClient = useQueryClient();
+  const submissionsQuery = useQuery({ queryKey: ["admin", "submissions"], queryFn: getSubmissions });
+  const submissions = submissionsQuery.data ?? [];
+
+  const [searchTerm, setSearchTerm] = useState("");
+  const [updatingId, setUpdatingId] = useState<number | null>(null);
+
+  const filtered = useMemo(() => {
+    const normalizedQuery = searchTerm.trim().toLowerCase();
+    return (submissions ?? []).filter((s) => {
+      if (statusParam === "reviewed" && !s.reviewed) return false;
+      if (statusParam === "new" && s.reviewed) return false;
+      if (dateParam === "today") {
+        if (!isToday(new Date(s.createdAt))) return false;
+      }
+      if (!normalizedQuery) return true;
+      const hay = `${s.name} ${s.email} ${s.message} ${s.service ?? ""}`.toLowerCase();
+      return hay.includes(normalizedQuery);
+    });
+  }, [submissions, statusParam, dateParam, searchTerm]);
+
+  const handleToggleReviewed = async (submission: Submission) => {
+    if (updatingId) return;
+    const nextStatus = submission.reviewed ? "new" : "reviewed";
+    setUpdatingId(submission.id);
+    try {
+      const updated = await updateSubmissionStatus(submission.id, nextStatus);
+      queryClient.setQueryData<Submission[] | undefined>(["admin", "submissions"], (current) => {
+        if (!current) return [updated];
+        return current.map((item) => (item.id === updated.id ? updated : item));
+      });
+      toast.success(nextStatus === "reviewed" ? "Submission marked as reviewed" : "Submission marked as new");
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Unable to update submission status.");
+    } finally {
+      setUpdatingId(null);
+    }
+  };
+
+  const handleDelete = async (submission: Submission) => {
+    if (updatingId) return;
+    setUpdatingId(submission.id);
+    try {
+      await deleteSubmission(submission.id);
+      queryClient.setQueryData<Submission[] | undefined>(["admin", "submissions"], (current) =>
+        current ? current.filter((s) => s.id !== submission.id) : [],
+      );
+      toast.success("Submission deleted");
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Unable to delete submission.");
+    } finally {
+      setUpdatingId(null);
+    }
+  };
+
+  return (
+    <section className="mx-auto flex w-full max-w-6xl flex-col gap-6">
+      <header className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-slate-900 md:text-3xl">Recent submissions</h1>
+          <p className="text-sm text-muted-foreground md:text-base">Search, filter, review and manage inbound inquiries.</p>
+        </div>
+        <Button type="button" variant="outline" onClick={() => submissionsQuery.refetch()} disabled={submissionsQuery.isFetching}>
+          {submissionsQuery.isFetching && <Loader2 className="h-4 w-4 animate-spin" />} Sync now
+        </Button>
+      </header>
+
+      <Card className="border-none bg-white shadow-sm">
+        <CardHeader>
+          <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+            <div>
+              <CardTitle>All submissions</CardTitle>
+              <CardDescription>Showing {filtered.length} of {submissions.length} total submissions.</CardDescription>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-5">
+          <div className="flex items-center gap-2">
+            <div className="relative w-full max-w-md">
+              <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <Input value={searchTerm} onChange={(e) => setSearchTerm(e.target.value)} placeholder="Search by name, email, or message" className="pl-9" />
+            </div>
+          </div>
+          <div className="overflow-hidden rounded-lg border">
+            <div className="max-h-[620px] overflow-auto">
+              <table className="min-w-full divide-y divide-border text-sm">
+                <thead className="bg-muted/60 text-left uppercase text-xs text-muted-foreground">
+                  <tr>
+                    <th className="px-4 py-3 font-semibold">Submitted</th>
+                    <th className="px-4 py-3 font-semibold">Contact</th>
+                    <th className="px-4 py-3 font-semibold">Inquiry</th>
+                    <th className="px-4 py-3 font-semibold">Status</th>
+                    <th className="px-4 py-3 font-semibold text-right">Actions</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border bg-white">
+                  {submissionsQuery.isLoading ? (
+                    <tr>
+                      <td colSpan={5} className="px-6 py-16 text-center text-muted-foreground">
+                        <div className="flex flex-col items-center gap-3">
+                          <Loader2 className="h-6 w-6 animate-spin text-primary" />
+                          <span>Loading submissions...</span>
+                        </div>
+                      </td>
+                    </tr>
+                  ) : filtered.length === 0 ? (
+                    <tr>
+                      <td colSpan={5} className="px-6 py-10 text-center text-muted-foreground">No submissions match the current filters.</td>
+                    </tr>
+                  ) : (
+                    filtered.map((submission) => {
+                      const createdAt = new Date(submission.createdAt);
+                      const submittedLabel = `${format(createdAt, "MMM d, yyyy HH:mm")}`;
+                      const relativeLabel = formatDistanceToNow(createdAt, { addSuffix: true });
+                      return (
+                        <tr key={submission.id} className="align-top">
+                          <td className="px-4 py-4 text-sm text-muted-foreground">
+                            <div className="font-medium text-slate-900">{submittedLabel}</div>
+                            <div className="text-xs">{relativeLabel}</div>
+                          </td>
+                          <td className="px-4 py-4">
+                            <div className="font-medium text-slate-900">{submission.name}</div>
+                            <div className="mt-1 flex flex-col gap-1 text-xs text-muted-foreground">
+                              <span className="flex items-center gap-1">
+                                <Mail className="h-3.5 w-3.5" />
+                                {submission.email}
+                              </span>
+                              {submission.phone && (
+                                <span className="flex items-center gap-1">
+                                  <span className="text-[10px] uppercase tracking-wide text-muted-foreground/70">Tel</span>
+                                  {submission.phone}
+                                </span>
+                              )}
+                            </div>
+                          </td>
+                          <td className="px-4 py-4">
+                            <div className="flex items-center gap-2">
+                              <Badge variant="secondary">{labelForType(submission)}</Badge>
+                              {submission.service && (
+                                <span className="text-xs text-muted-foreground">{formatService(submission.service)}</span>
+                              )}
+                            </div>
+                            <p className="mt-2 max-w-xs truncate text-sm text-muted-foreground" title={submission.message}>
+                              {submission.message}
+                            </p>
+                          </td>
+                          <td className="px-4 py-4"><StatusBadge submission={submission} /></td>
+                          <td className="px-4 py-4 text-right">
+                            <div className="flex items-center justify-end gap-2">
+                              <Button type="button" variant="outline" size="sm" onClick={() => handleToggleReviewed(submission)} disabled={updatingId === submission.id}>
+                                {updatingId === submission.id && <Loader2 className="h-4 w-4 animate-spin" />}
+                                Mark as {submission.reviewed ? "new" : "reviewed"}
+                              </Button>
+                              <AlertDialog>
+                                <AlertDialogTrigger asChild>
+                                  <Button variant="destructive" size="sm" disabled={updatingId === submission.id}>
+                                    <Trash2 className="h-4 w-4" /> Delete
+                                  </Button>
+                                </AlertDialogTrigger>
+                                <AlertDialogContent>
+                                  <AlertDialogHeader>
+                                    <AlertDialogTitle>Delete this submission?</AlertDialogTitle>
+                                    <AlertDialogDescription>This action cannot be undone. This will permanently remove the selected submission.</AlertDialogDescription>
+                                  </AlertDialogHeader>
+                                  <AlertDialogFooter>
+                                    <AlertDialogCancel>Cancel</AlertDialogCancel>
+                                    <AlertDialogAction onClick={() => handleDelete(submission)}>Delete</AlertDialogAction>
+                                  </AlertDialogFooter>
+                                </AlertDialogContent>
+                              </AlertDialog>
+                            </div>
+                          </td>
+                        </tr>
+                      );
+                    })
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </section>
+  );
+}

--- a/client/pages/admin/AdminSubmissions.tsx
+++ b/client/pages/admin/AdminSubmissions.tsx
@@ -11,7 +11,13 @@ import {
 } from "@/lib/submissions";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
 import { Loader2, Mail, Search, Trash2 } from "lucide-react";
@@ -56,11 +62,15 @@ function formatService(value: string) {
 function StatusBadge({ submission }: { submission: Submission }) {
   if (submission.reviewed) {
     return (
-      <Badge className="bg-emerald-100 text-emerald-700 hover:bg-emerald-100">Reviewed</Badge>
+      <Badge className="bg-emerald-100 text-emerald-700 hover:bg-emerald-100">
+        Reviewed
+      </Badge>
     );
   }
   return (
-    <Badge variant="outline" className="border-amber-300 text-amber-600">Awaiting review</Badge>
+    <Badge variant="outline" className="border-amber-300 text-amber-600">
+      Awaiting review
+    </Badge>
   );
 }
 
@@ -70,7 +80,10 @@ export default function AdminSubmissions() {
   const dateParam = params.get("date");
 
   const queryClient = useQueryClient();
-  const submissionsQuery = useQuery({ queryKey: ["admin", "submissions"], queryFn: getSubmissions });
+  const submissionsQuery = useQuery({
+    queryKey: ["admin", "submissions"],
+    queryFn: getSubmissions,
+  });
   const submissions = submissionsQuery.data ?? [];
 
   const [searchTerm, setSearchTerm] = useState("");
@@ -85,7 +98,8 @@ export default function AdminSubmissions() {
         if (!isToday(new Date(s.createdAt))) return false;
       }
       if (!normalizedQuery) return true;
-      const hay = `${s.name} ${s.email} ${s.message} ${s.service ?? ""}`.toLowerCase();
+      const hay =
+        `${s.name} ${s.email} ${s.message} ${s.service ?? ""}`.toLowerCase();
       return hay.includes(normalizedQuery);
     });
   }, [submissions, statusParam, dateParam, searchTerm]);
@@ -96,13 +110,24 @@ export default function AdminSubmissions() {
     setUpdatingId(submission.id);
     try {
       const updated = await updateSubmissionStatus(submission.id, nextStatus);
-      queryClient.setQueryData<Submission[] | undefined>(["admin", "submissions"], (current) => {
-        if (!current) return [updated];
-        return current.map((item) => (item.id === updated.id ? updated : item));
-      });
-      toast.success(nextStatus === "reviewed" ? "Submission marked as reviewed" : "Submission marked as new");
+      queryClient.setQueryData<Submission[] | undefined>(
+        ["admin", "submissions"],
+        (current) => {
+          if (!current) return [updated];
+          return current.map((item) =>
+            item.id === updated.id ? updated : item,
+          );
+        },
+      );
+      toast.success(
+        nextStatus === "reviewed"
+          ? "Submission marked as reviewed"
+          : "Submission marked as new",
+      );
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : "Unable to update submission status.");
+      toast.error(
+        e instanceof Error ? e.message : "Unable to update submission status.",
+      );
     } finally {
       setUpdatingId(null);
     }
@@ -113,12 +138,16 @@ export default function AdminSubmissions() {
     setUpdatingId(submission.id);
     try {
       await deleteSubmission(submission.id);
-      queryClient.setQueryData<Submission[] | undefined>(["admin", "submissions"], (current) =>
-        current ? current.filter((s) => s.id !== submission.id) : [],
+      queryClient.setQueryData<Submission[] | undefined>(
+        ["admin", "submissions"],
+        (current) =>
+          current ? current.filter((s) => s.id !== submission.id) : [],
       );
       toast.success("Submission deleted");
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : "Unable to delete submission.");
+      toast.error(
+        e instanceof Error ? e.message : "Unable to delete submission.",
+      );
     } finally {
       setUpdatingId(null);
     }
@@ -128,11 +157,23 @@ export default function AdminSubmissions() {
     <section className="mx-auto flex w-full max-w-6xl flex-col gap-6">
       <header className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
         <div>
-          <h1 className="text-2xl font-semibold text-slate-900 md:text-3xl">Recent submissions</h1>
-          <p className="text-sm text-muted-foreground md:text-base">Search, filter, review and manage inbound inquiries.</p>
+          <h1 className="text-2xl font-semibold text-slate-900 md:text-3xl">
+            Recent submissions
+          </h1>
+          <p className="text-sm text-muted-foreground md:text-base">
+            Search, filter, review and manage inbound inquiries.
+          </p>
         </div>
-        <Button type="button" variant="outline" onClick={() => submissionsQuery.refetch()} disabled={submissionsQuery.isFetching}>
-          {submissionsQuery.isFetching && <Loader2 className="h-4 w-4 animate-spin" />} Sync now
+        <Button
+          type="button"
+          variant="outline"
+          onClick={() => submissionsQuery.refetch()}
+          disabled={submissionsQuery.isFetching}
+        >
+          {submissionsQuery.isFetching && (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          )}{" "}
+          Sync now
         </Button>
       </header>
 
@@ -141,7 +182,10 @@ export default function AdminSubmissions() {
           <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
             <div>
               <CardTitle>All submissions</CardTitle>
-              <CardDescription>Showing {filtered.length} of {submissions.length} total submissions.</CardDescription>
+              <CardDescription>
+                Showing {filtered.length} of {submissions.length} total
+                submissions.
+              </CardDescription>
             </div>
           </div>
         </CardHeader>
@@ -149,7 +193,12 @@ export default function AdminSubmissions() {
           <div className="flex items-center gap-2">
             <div className="relative w-full max-w-md">
               <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-              <Input value={searchTerm} onChange={(e) => setSearchTerm(e.target.value)} placeholder="Search by name, email, or message" className="pl-9" />
+              <Input
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+                placeholder="Search by name, email, or message"
+                className="pl-9"
+              />
             </div>
           </div>
           <div className="overflow-hidden rounded-lg border">
@@ -161,13 +210,18 @@ export default function AdminSubmissions() {
                     <th className="px-4 py-3 font-semibold">Contact</th>
                     <th className="px-4 py-3 font-semibold">Inquiry</th>
                     <th className="px-4 py-3 font-semibold">Status</th>
-                    <th className="px-4 py-3 font-semibold text-right">Actions</th>
+                    <th className="px-4 py-3 font-semibold text-right">
+                      Actions
+                    </th>
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-border bg-white">
                   {submissionsQuery.isLoading ? (
                     <tr>
-                      <td colSpan={5} className="px-6 py-16 text-center text-muted-foreground">
+                      <td
+                        colSpan={5}
+                        className="px-6 py-16 text-center text-muted-foreground"
+                      >
                         <div className="flex flex-col items-center gap-3">
                           <Loader2 className="h-6 w-6 animate-spin text-primary" />
                           <span>Loading submissions...</span>
@@ -176,21 +230,32 @@ export default function AdminSubmissions() {
                     </tr>
                   ) : filtered.length === 0 ? (
                     <tr>
-                      <td colSpan={5} className="px-6 py-10 text-center text-muted-foreground">No submissions match the current filters.</td>
+                      <td
+                        colSpan={5}
+                        className="px-6 py-10 text-center text-muted-foreground"
+                      >
+                        No submissions match the current filters.
+                      </td>
                     </tr>
                   ) : (
                     filtered.map((submission) => {
                       const createdAt = new Date(submission.createdAt);
                       const submittedLabel = `${format(createdAt, "MMM d, yyyy HH:mm")}`;
-                      const relativeLabel = formatDistanceToNow(createdAt, { addSuffix: true });
+                      const relativeLabel = formatDistanceToNow(createdAt, {
+                        addSuffix: true,
+                      });
                       return (
                         <tr key={submission.id} className="align-top">
                           <td className="px-4 py-4 text-sm text-muted-foreground">
-                            <div className="font-medium text-slate-900">{submittedLabel}</div>
+                            <div className="font-medium text-slate-900">
+                              {submittedLabel}
+                            </div>
                             <div className="text-xs">{relativeLabel}</div>
                           </td>
                           <td className="px-4 py-4">
-                            <div className="font-medium text-slate-900">{submission.name}</div>
+                            <div className="font-medium text-slate-900">
+                              {submission.name}
+                            </div>
                             <div className="mt-1 flex flex-col gap-1 text-xs text-muted-foreground">
                               <span className="flex items-center gap-1">
                                 <Mail className="h-3.5 w-3.5" />
@@ -198,7 +263,9 @@ export default function AdminSubmissions() {
                               </span>
                               {submission.phone && (
                                 <span className="flex items-center gap-1">
-                                  <span className="text-[10px] uppercase tracking-wide text-muted-foreground/70">Tel</span>
+                                  <span className="text-[10px] uppercase tracking-wide text-muted-foreground/70">
+                                    Tel
+                                  </span>
                                   {submission.phone}
                                 </span>
                               )}
@@ -206,36 +273,70 @@ export default function AdminSubmissions() {
                           </td>
                           <td className="px-4 py-4">
                             <div className="flex items-center gap-2">
-                              <Badge variant="secondary">{labelForType(submission)}</Badge>
+                              <Badge variant="secondary">
+                                {labelForType(submission)}
+                              </Badge>
                               {submission.service && (
-                                <span className="text-xs text-muted-foreground">{formatService(submission.service)}</span>
+                                <span className="text-xs text-muted-foreground">
+                                  {formatService(submission.service)}
+                                </span>
                               )}
                             </div>
-                            <p className="mt-2 max-w-xs truncate text-sm text-muted-foreground" title={submission.message}>
+                            <p
+                              className="mt-2 max-w-xs truncate text-sm text-muted-foreground"
+                              title={submission.message}
+                            >
                               {submission.message}
                             </p>
                           </td>
-                          <td className="px-4 py-4"><StatusBadge submission={submission} /></td>
+                          <td className="px-4 py-4">
+                            <StatusBadge submission={submission} />
+                          </td>
                           <td className="px-4 py-4 text-right">
                             <div className="flex items-center justify-end gap-2">
-                              <Button type="button" variant="outline" size="sm" onClick={() => handleToggleReviewed(submission)} disabled={updatingId === submission.id}>
-                                {updatingId === submission.id && <Loader2 className="h-4 w-4 animate-spin" />}
-                                Mark as {submission.reviewed ? "new" : "reviewed"}
+                              <Button
+                                type="button"
+                                variant="outline"
+                                size="sm"
+                                onClick={() => handleToggleReviewed(submission)}
+                                disabled={updatingId === submission.id}
+                              >
+                                {updatingId === submission.id && (
+                                  <Loader2 className="h-4 w-4 animate-spin" />
+                                )}
+                                Mark as{" "}
+                                {submission.reviewed ? "new" : "reviewed"}
                               </Button>
                               <AlertDialog>
                                 <AlertDialogTrigger asChild>
-                                  <Button variant="destructive" size="sm" disabled={updatingId === submission.id}>
+                                  <Button
+                                    variant="destructive"
+                                    size="sm"
+                                    disabled={updatingId === submission.id}
+                                  >
                                     <Trash2 className="h-4 w-4" /> Delete
                                   </Button>
                                 </AlertDialogTrigger>
                                 <AlertDialogContent>
                                   <AlertDialogHeader>
-                                    <AlertDialogTitle>Delete this submission?</AlertDialogTitle>
-                                    <AlertDialogDescription>This action cannot be undone. This will permanently remove the selected submission.</AlertDialogDescription>
+                                    <AlertDialogTitle>
+                                      Delete this submission?
+                                    </AlertDialogTitle>
+                                    <AlertDialogDescription>
+                                      This action cannot be undone. This will
+                                      permanently remove the selected
+                                      submission.
+                                    </AlertDialogDescription>
                                   </AlertDialogHeader>
                                   <AlertDialogFooter>
-                                    <AlertDialogCancel>Cancel</AlertDialogCancel>
-                                    <AlertDialogAction onClick={() => handleDelete(submission)}>Delete</AlertDialogAction>
+                                    <AlertDialogCancel>
+                                      Cancel
+                                    </AlertDialogCancel>
+                                    <AlertDialogAction
+                                      onClick={() => handleDelete(submission)}
+                                    >
+                                      Delete
+                                    </AlertDialogAction>
                                   </AlertDialogFooter>
                                 </AlertDialogContent>
                               </AlertDialog>

--- a/client/pages/admin/AdminTeam.tsx
+++ b/client/pages/admin/AdminTeam.tsx
@@ -1,0 +1,17 @@
+import UsersCard from "./components/UsersCard";
+import { useQuery } from "@tanstack/react-query";
+import { getAdminUsers } from "@/lib/submissions";
+
+export default function AdminTeam() {
+  const usersQuery = useQuery({ queryKey: ["admin", "users"], queryFn: getAdminUsers });
+
+  return (
+    <section className="mx-auto w-full max-w-3xl">
+      <div className="mb-6">
+        <h1 className="text-2xl font-semibold text-slate-900 md:text-3xl">Admin team</h1>
+        <p className="text-sm text-muted-foreground md:text-base">Manage accounts with console access.</p>
+      </div>
+      <UsersCard users={usersQuery.data ?? []} loading={usersQuery.isLoading} fetching={usersQuery.isFetching} />
+    </section>
+  );
+}

--- a/client/pages/admin/AdminTeam.tsx
+++ b/client/pages/admin/AdminTeam.tsx
@@ -3,15 +3,26 @@ import { useQuery } from "@tanstack/react-query";
 import { getAdminUsers } from "@/lib/submissions";
 
 export default function AdminTeam() {
-  const usersQuery = useQuery({ queryKey: ["admin", "users"], queryFn: getAdminUsers });
+  const usersQuery = useQuery({
+    queryKey: ["admin", "users"],
+    queryFn: getAdminUsers,
+  });
 
   return (
     <section className="mx-auto w-full max-w-3xl">
       <div className="mb-6">
-        <h1 className="text-2xl font-semibold text-slate-900 md:text-3xl">Admin team</h1>
-        <p className="text-sm text-muted-foreground md:text-base">Manage accounts with console access.</p>
+        <h1 className="text-2xl font-semibold text-slate-900 md:text-3xl">
+          Admin team
+        </h1>
+        <p className="text-sm text-muted-foreground md:text-base">
+          Manage accounts with console access.
+        </p>
       </div>
-      <UsersCard users={usersQuery.data ?? []} loading={usersQuery.isLoading} fetching={usersQuery.isFetching} />
+      <UsersCard
+        users={usersQuery.data ?? []}
+        loading={usersQuery.isLoading}
+        fetching={usersQuery.isFetching}
+      />
     </section>
   );
 }

--- a/client/pages/admin/components/LatestLeadCard.tsx
+++ b/client/pages/admin/components/LatestLeadCard.tsx
@@ -1,0 +1,72 @@
+import { Loader2 } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import type { Submission } from "@/lib/submissions";
+import { formatDistanceToNow } from "date-fns";
+
+function labelForType(submission: Submission) {
+  switch (submission.normalizedType) {
+    case "service":
+      return "Service request";
+    case "consultation":
+      return "Consultation";
+    case "general":
+      return "General inquiry";
+    default:
+      return submission.type || "Other";
+  }
+}
+
+function formatService(value: string) {
+  switch (value) {
+    case "hydropower":
+      return "Hydropower";
+    case "mv":
+      return "Large Power & MV";
+    case "sollatek":
+      return "Sollatek Protection";
+    default:
+      return value;
+  }
+}
+
+export default function LatestLeadCard({ submission, loading }: { submission: Submission | null; loading: boolean }) {
+  return (
+    <Card className="border-none bg-white shadow-sm">
+      <CardHeader>
+        <CardTitle>Latest lead</CardTitle>
+        <CardDescription>
+          {submission ? "Most recent inbound inquiry." : "New leads appear here."}
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {loading ? (
+          <div className="flex items-center justify-center py-12 text-muted-foreground">
+            <Loader2 className="h-5 w-5 animate-spin" />
+          </div>
+        ) : submission ? (
+          <div className="space-y-4">
+            <div>
+              <p className="text-lg font-semibold text-slate-900">{submission.name}</p>
+              <p className="text-sm text-muted-foreground">{submission.email}</p>
+            </div>
+            <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+              <Badge variant="secondary">{labelForType(submission)}</Badge>
+              {submission.service && <Badge variant="outline">{formatService(submission.service)}</Badge>}
+            </div>
+            <Separator />
+            <p className="text-sm leading-relaxed text-muted-foreground">{submission.message}</p>
+            <p className="text-xs text-muted-foreground">
+              {formatDistanceToNow(new Date(submission.createdAt), { addSuffix: true })}
+            </p>
+          </div>
+        ) : (
+          <p className="py-8 text-sm text-muted-foreground">
+            You are all caught up. Invite prospects to reach out via the contact page to see their messages here.
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/client/pages/admin/components/LatestLeadCard.tsx
+++ b/client/pages/admin/components/LatestLeadCard.tsx
@@ -1,6 +1,12 @@
 import { Loader2 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
 import type { Submission } from "@/lib/submissions";
 import { formatDistanceToNow } from "date-fns";
@@ -31,13 +37,21 @@ function formatService(value: string) {
   }
 }
 
-export default function LatestLeadCard({ submission, loading }: { submission: Submission | null; loading: boolean }) {
+export default function LatestLeadCard({
+  submission,
+  loading,
+}: {
+  submission: Submission | null;
+  loading: boolean;
+}) {
   return (
     <Card className="border-none bg-white shadow-sm">
       <CardHeader>
         <CardTitle>Latest lead</CardTitle>
         <CardDescription>
-          {submission ? "Most recent inbound inquiry." : "New leads appear here."}
+          {submission
+            ? "Most recent inbound inquiry."
+            : "New leads appear here."}
         </CardDescription>
       </CardHeader>
       <CardContent>
@@ -48,22 +62,35 @@ export default function LatestLeadCard({ submission, loading }: { submission: Su
         ) : submission ? (
           <div className="space-y-4">
             <div>
-              <p className="text-lg font-semibold text-slate-900">{submission.name}</p>
-              <p className="text-sm text-muted-foreground">{submission.email}</p>
+              <p className="text-lg font-semibold text-slate-900">
+                {submission.name}
+              </p>
+              <p className="text-sm text-muted-foreground">
+                {submission.email}
+              </p>
             </div>
             <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
               <Badge variant="secondary">{labelForType(submission)}</Badge>
-              {submission.service && <Badge variant="outline">{formatService(submission.service)}</Badge>}
+              {submission.service && (
+                <Badge variant="outline">
+                  {formatService(submission.service)}
+                </Badge>
+              )}
             </div>
             <Separator />
-            <p className="text-sm leading-relaxed text-muted-foreground">{submission.message}</p>
+            <p className="text-sm leading-relaxed text-muted-foreground">
+              {submission.message}
+            </p>
             <p className="text-xs text-muted-foreground">
-              {formatDistanceToNow(new Date(submission.createdAt), { addSuffix: true })}
+              {formatDistanceToNow(new Date(submission.createdAt), {
+                addSuffix: true,
+              })}
             </p>
           </div>
         ) : (
           <p className="py-8 text-sm text-muted-foreground">
-            You are all caught up. Invite prospects to reach out via the contact page to see their messages here.
+            You are all caught up. Invite prospects to reach out via the contact
+            page to see their messages here.
           </p>
         )}
       </CardContent>

--- a/client/pages/admin/components/UsersCard.tsx
+++ b/client/pages/admin/components/UsersCard.tsx
@@ -1,0 +1,63 @@
+import { Loader2 } from "lucide-react";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import type { AdminUser } from "@/lib/submissions";
+import { cn } from "@/lib/utils";
+
+function UserRow({ user }: { user: AdminUser }) {
+  const lastLoginLabel = user.last_login
+    ? new Date(user.last_login).toLocaleString()
+    : "No activity recorded";
+
+  return (
+    <div className="rounded-lg border border-border bg-muted/30 p-4">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <p className="text-sm font-semibold text-slate-900">{user.username}</p>
+          <p className="text-xs text-muted-foreground">{user.email}</p>
+        </div>
+        <Badge
+          variant={user.is_active === false ? "outline" : "secondary"}
+          className={cn(
+            user.is_active === false ? "border-amber-300 text-amber-600" : "bg-emerald-100 text-emerald-700",
+          )}
+        >
+          {user.is_active === false ? "Inactive" : "Active"}
+        </Badge>
+      </div>
+      <p className="mt-3 text-xs text-muted-foreground">Last login: {lastLoginLabel}</p>
+    </div>
+  );
+}
+
+export default function UsersCard({ users, loading, fetching }: { users: AdminUser[]; loading: boolean; fetching: boolean }) {
+  return (
+    <Card className="border-none bg-white shadow-sm">
+      <CardHeader className="flex flex-row items-start justify-between">
+        <div>
+          <CardTitle>Admin team</CardTitle>
+          <CardDescription>Accounts with access to this console.</CardDescription>
+        </div>
+        {fetching && <Loader2 className="h-4 w-4 animate-spin text-primary" />}
+      </CardHeader>
+      <CardContent>
+        {loading ? (
+          <div className="flex items-center justify-center py-12 text-muted-foreground">
+            <Loader2 className="h-5 w-5 animate-spin" />
+          </div>
+        ) : users.length === 0 ? (
+          <p className="py-8 text-sm text-muted-foreground">No admins found. Share the signup link to onboard your team.</p>
+        ) : (
+          <ScrollArea className="max-h-[420px] pr-2">
+            <div className="space-y-4">
+              {users.map((user) => (
+                <UserRow key={user.id} user={user} />
+              ))}
+            </div>
+          </ScrollArea>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/client/pages/admin/components/UsersCard.tsx
+++ b/client/pages/admin/components/UsersCard.tsx
@@ -1,7 +1,13 @@
 import { Loader2 } from "lucide-react";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Badge } from "@/components/ui/badge";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import type { AdminUser } from "@/lib/submissions";
 import { cn } from "@/lib/utils";
 
@@ -14,30 +20,46 @@ function UserRow({ user }: { user: AdminUser }) {
     <div className="rounded-lg border border-border bg-muted/30 p-4">
       <div className="flex items-start justify-between gap-4">
         <div>
-          <p className="text-sm font-semibold text-slate-900">{user.username}</p>
+          <p className="text-sm font-semibold text-slate-900">
+            {user.username}
+          </p>
           <p className="text-xs text-muted-foreground">{user.email}</p>
         </div>
         <Badge
           variant={user.is_active === false ? "outline" : "secondary"}
           className={cn(
-            user.is_active === false ? "border-amber-300 text-amber-600" : "bg-emerald-100 text-emerald-700",
+            user.is_active === false
+              ? "border-amber-300 text-amber-600"
+              : "bg-emerald-100 text-emerald-700",
           )}
         >
           {user.is_active === false ? "Inactive" : "Active"}
         </Badge>
       </div>
-      <p className="mt-3 text-xs text-muted-foreground">Last login: {lastLoginLabel}</p>
+      <p className="mt-3 text-xs text-muted-foreground">
+        Last login: {lastLoginLabel}
+      </p>
     </div>
   );
 }
 
-export default function UsersCard({ users, loading, fetching }: { users: AdminUser[]; loading: boolean; fetching: boolean }) {
+export default function UsersCard({
+  users,
+  loading,
+  fetching,
+}: {
+  users: AdminUser[];
+  loading: boolean;
+  fetching: boolean;
+}) {
   return (
     <Card className="border-none bg-white shadow-sm">
       <CardHeader className="flex flex-row items-start justify-between">
         <div>
           <CardTitle>Admin team</CardTitle>
-          <CardDescription>Accounts with access to this console.</CardDescription>
+          <CardDescription>
+            Accounts with access to this console.
+          </CardDescription>
         </div>
         {fetching && <Loader2 className="h-4 w-4 animate-spin text-primary" />}
       </CardHeader>
@@ -47,7 +69,9 @@ export default function UsersCard({ users, loading, fetching }: { users: AdminUs
             <Loader2 className="h-5 w-5 animate-spin" />
           </div>
         ) : users.length === 0 ? (
-          <p className="py-8 text-sm text-muted-foreground">No admins found. Share the signup link to onboard your team.</p>
+          <p className="py-8 text-sm text-muted-foreground">
+            No admins found. Share the signup link to onboard your team.
+          </p>
         ) : (
           <ScrollArea className="max-h-[420px] pr-2">
             <div className="space-y-4">


### PR DESCRIPTION
## Purpose

The user requested a complete restructuring of the admin dashboard to improve navigation and organization. The main goals were to:

- Move specific sections (latest lead, admin team, recent submissions) from the overview to dedicated sidebar options
- Clean up the overview page to focus only on key metrics cards (total inquiries, review rate, new today, active admins)
- Make metric cards clickable to redirect to detailed pages
- Remove redundant "latest lead" tracking from multiple locations
- Consolidate lead tracking under "recent submissions" only

## Code changes

- **New admin pages**: Added 4 new dedicated admin pages (`AdminSubmissions`, `AdminNewToday`, `AdminActiveAdmins`, `AdminTeam`) with corresponding routes
- **Sidebar navigation**: Enhanced `AdminAppLayout` with new navigation links for recent submissions, new today, active admins, and admin team
- **Component extraction**: Created reusable `LatestLeadCard` and `UsersCard` components for better code organization
- **Dashboard cleanup**: Streamlined `AdminDashboard` to focus on overview metrics and removed redundant sections
- **Enhanced functionality**: Added submission deletion capability with confirmation dialog
- **UI improvements**: Updated sidebar width, spacing, and added snake cursor component
- **Navigation structure**: Implemented proper routing for all new admin sections with consistent layoutTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/dd99dcdd6efd4020a46c175fb0808d47/aura-garden)

👀 [Preview Link](https://dd99dcdd6efd4020a46c175fb0808d47-aura-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>dd99dcdd6efd4020a46c175fb0808d47</projectId>-->
<!--<branchName>aura-garden</branchName>-->